### PR TITLE
Update _fontface.scss

### DIFF
--- a/sass/_fontface.scss
+++ b/sass/_fontface.scss
@@ -1,14 +1,14 @@
 
-$fontpath: '../fonts';
+$americons-fontpath: '../fonts' !default;
 
 @font-face {
     font-family: 'Americons';
     font-style: normal;
     font-weight: normal;
-    src: url('#{$fontpath}/americons.eot?#iefix');
-    src: url('#{$fontpath}/americons.eot?#iefix') format('embedded-opentype'),
-         url('#{$fontpath}/americons.woff2') format('woff2'),
-         url('#{$fontpath}/americons.woff') format('woff'),
-         url('#{$fontpath}/americons.ttf') format('truetype'),
-         url('#{$fontpath}/americons.svg') format('svg');
+    src: url('#{$americons-fontpath}/americons.eot?#iefix');
+    src: url('#{$americons-fontpath}/americons.eot?#iefix') format('embedded-opentype'),
+         url('#{$americons-fontpath}/americons.woff2') format('woff2'),
+         url('#{$americons-fontpath}/americons.woff') format('woff'),
+         url('#{$americons-fontpath}/americons.ttf') format('truetype'),
+         url('#{$americons-fontpath}/americons.svg') format('svg');
 }


### PR DESCRIPTION
Two minor changes:

1) It would be nice to be able to override the font path. For reasons unknown to me (still learning) we have to do this with the angular-cli in order for the Webpack build to complete successfully.

2) Give $fontpath a more project specific name just in case it might conflict with another project in the future.